### PR TITLE
fix: typo on readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The binary will be created on `./bin` dir.
 
 ### OPTIONAL
 
-`-metrics.filter` : List of metrics sepparated by comma
+`-metrics.filter` : List of metrics separated by comma
 
 * Supported metrics are:
 
@@ -135,7 +135,7 @@ Some issues that we need you help:
 * Writing tests
 * Improving the Documentation
 * Split the API Library to an external repo
-* Improve CLI options to enable metrics dynamicaly
+* Improve CLI options to enable metrics dynamically
 * Open an issue
 > [...]
 
@@ -143,5 +143,5 @@ Contribution guidelines:
 
 * See [License](./LICENSE)
 * Fork me
-* Open an PR with enhancements, bugfixes, etc
-* Request review from collavorators
+* Open a PR with enhancements, bugfixes, etc
+* Request review from collaborators


### PR DESCRIPTION
I based on plugin Grammarly after reading `collavorators` in this file.

![image](https://user-images.githubusercontent.com/8202898/65444612-c5ba4600-de06-11e9-9bd3-8c43ce09a8a0.png)
